### PR TITLE
Add new equation category :implicite_diffeq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /docs/Manifest.toml
 /docs/build/
 /docs/src/generated/
+.vscode

--- a/examples/kuramoto_network.jl
+++ b/examples/kuramoto_network.jl
@@ -1,6 +1,6 @@
 #=
 ## Integration with `NetworkDynamics.jl`
-In this example we model a Network based on the [Kuroamoto model](https://en.wikipedia.org/wiki/Kuramoto_model) using the [`NetworkDynamics.jl`](https://github.com/FHell/NetworkDynamics.jl) package.
+In this example we model a Network based on the [Kuramoto model](https://en.wikipedia.org/wiki/Kuramoto_model) using the [`NetworkDynamics.jl`](https://github.com/FHell/NetworkDynamics.jl) package.
 =#
 
 using NetworkDynamics

--- a/examples/kuramoto_without_nd.jl
+++ b/examples/kuramoto_without_nd.jl
@@ -53,7 +53,7 @@ function gen_vertex_block(n_edges, name)
     @parameters t ω
     @variables ϕ(t)
     D = Differential(t)
-    ## the way array variables work changed. This is a hack to retrieve the old behvaviour of
+    ## the way array variables work changed. This is a hack to retrieve the old behavior of
     ## this closely mimics the old @parameters edge[1:n_edges](t)
     edge = Num[]
     for i in 1:n_edges

--- a/examples/pd_node.jl
+++ b/examples/pd_node.jl
@@ -108,7 +108,7 @@ i_i -->|         |--> u_i
        +---------+
 ```
 
-We can achieve this by defining a nother block which converts `(i, u) ↦ (P, Q)`
+We can achieve this by defining another block which converts `(i, u) ↦ (P, Q)`
 
 ```
                +----------+  +-------------+
@@ -207,7 +207,7 @@ para = Dict(
     :V_r => 1.0,   # reference/ desired voltage
     :P   => 0.303, # active (real) power infeed
     :Q   => 0.126, # reactive (imag) power infeed                .
-    :ω_r => 0.0)   # refrence/ desired frequency
+    :ω_r => 0.0)   # reference/ desired frequency
 nothing #hide
 
 # Now let's test whether this works in PD...
@@ -269,7 +269,7 @@ using Test
         node_pd = VSIVoltagePT1(; nt...)
         f_pd = construct_vertex(node_pd).f
 
-        ## create fake "edge data", 4 incoming, 4 outgooing with 4 states each
+        ## create fake "edge data", 4 incoming, 4 outgoing with 4 states each
         es = [randn(4) for i in 1:4]
         ed = [randn(4) for i in 1:4]
 

--- a/examples/spacecraft.jl
+++ b/examples/spacecraft.jl
@@ -149,7 +149,7 @@ In order to simulate the system we can have to build the Julia functions.
 gen = generate_io_function(space_controller)
 nothing # hide
 #=
-By doing so we get access to a named tuple with the fileds
+By doing so we get access to a named tuple with the fields
 - `gen.f_ip` in-place function
 - `gen.f_oop` out-of-place function
 - `gen.massm` mass matrix of the system

--- a/src/BlockSystems.jl
+++ b/src/BlockSystems.jl
@@ -65,7 +65,7 @@ struct IOBlock <: AbstractIOSystem
 
     function IOBlock(name, inputs, iparams, istates, outputs, odes, rem_eqs; warn)
         @check name == getname(odes) "Name of inner ODESystem does not match name of IOBlock"
-        @checkwarn warn Set(inputs) ⊆ Set(parameters(odes)) "Inputs should be parameters. You may ignore this warning if you want to speciy an input which is not used in the eqs."
+        @checkwarn warn Set(inputs) ⊆ Set(parameters(odes)) "Inputs should be parameters. You may ignore this warning if you want to specify an input which is not used in the eqs."
         @checkwarn warn Set(outputs) ⊆ Set(states(odes)) "Outputs should be variables. You may ignore this waring if you want to specify an output which is not used in the eqs (completly implicit)."
         @checkwarn warn Set(iparams) ⊆ Set(parameters(odes)) "iparams should be parameters of the eqs system"
         @checkwarn warn Set(istates) ⊆ Set(states(odes)) "istates should be variables of the eqs system"

--- a/src/BlockSystems.jl
+++ b/src/BlockSystems.jl
@@ -75,7 +75,7 @@ struct IOBlock <: AbstractIOSystem
         # lhs of the equation should be either differential of state/output
         for eq in equations(odes)
             (type, lhs_var) = eq_type(eq)
-            if type === :diffeq
+            if type === :explicit_diffeq
                 @check lhs_var ∈ Set(istates ∪ outputs) "$eq : Lhs variable of diff eqs should be istate or output."
             elseif type === :explicit_algebraic
                 @check lhs_var ∈ Set(istates ∪ outputs) "$eq : Lhs variable of explicit algebraic eqs should be istate or output."

--- a/src/function_generation.jl
+++ b/src/function_generation.jl
@@ -198,7 +198,7 @@ end
 function reorder_by_states(eqs::AbstractVector{Equation}, states)
     @assert length(eqs) == length(states) "Numbers of eqs should be equal to states!"
     # for each state, collect the eq_idx which corresponds some states (implicit
-    # agebraic) don't have special equations attached to them those are the "undused_idx"
+    # algebraic) don't have special equations attached to them those are the "undused_idx"
     eq_idx::Vector{Union{Int, Nothing}} = [findfirst(x->isequal(s, lhs_var(x)), eqs) for s in states]
     unused_idx = reverse(setdiff(1:length(eqs), eq_idx))
     for i in 1:length(eq_idx)

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -81,7 +81,7 @@ This function removes equations from block, which are not used in order to
 generate the outputs. It looks for equations which have no path to the outputs
 equations in the dependency graph. Returns a new IOBlock.
 
-The removed equations will be not avaiblable as removed quations of the new IOBlock
+The removed equations will be not available as removed equations of the new IOBlock
 
 TODO: Maybe we should try to reduce the inputs to.
 """
@@ -98,7 +98,7 @@ function remove_superfluous_states(iob::IOBlock; verbose=false, warn=true)
     output_idx = [findfirst(x->o ∈ Set(get_variables(x.lhs)), neweqs) for o in outputs]
 
     if any(isnothing, output_idx)
-        verbose && @info "Can't remove souperflous states if outputs implicitly defined."
+        verbose && @info "Can't remove superfluous states if outputs implicitly defined."
         return neweqs
     end
 
@@ -125,7 +125,7 @@ end
 Reduces the number of equations by substituting explicit algebraic equations.
 Returns a new IOBlock with the reduced equations. The removed eqs are stored
 together with the previous `removed_eqs` in the new IOBlock.
-Won't reduce algebraic states which are labeld as `output`.
+Won't reduce algebraic states which are labeled as `output`.
 """
 function substitute_algebraic_states(iob::IOBlock; verbose=false, warn=true)
     reduced_eqs = deepcopy(equations(iob))
@@ -151,7 +151,7 @@ function substitute_algebraic_states(iob::IOBlock; verbose=false, warn=true)
         reduced_eqs[i] = neweqs
     end
 
-    # also substitute in the allready removed_eqs
+    # also substitute in the already removed_eqs
     removed_eqs = deepcopy(iob.removed_eqs)
     for (i, eq) in enumerate(removed_eqs)
         removed_eqs[i] = eq.lhs ~ recursive_substitute(eq.rhs, rules)
@@ -170,8 +170,8 @@ end
 """
     _algebraic_substitution_rules(eqs; skip=nothing)
 
-Extract substition rules for explicit algebraic equations in given equations.
-Makes sure that those substitutiosn are pairwise cycle free.
+Extract substitution rules for explicit algebraic equations in given equations.
+Makes sure that those substitutions are pairwise cycle free.
 
 Returns Tuple of substitution dict and corresponding indices of algebraic equations
 in the given equations.
@@ -249,7 +249,7 @@ I.e.
 
 Process happens in multiple steps:
 - try to find explicit equation for differential
-- if none found try to recursivly substitute inside differential with known algebraic states
+- if none found try to recursively substitute inside differential with known algebraic states
 - expand derivatives and try again to substitute with known differentials
 
 """
@@ -268,7 +268,7 @@ function substitute_derivatives(iob::IOBlock; verbose=false, warn=true)
     algebraic_subs = Dict{Symbolic, Any}()
     function lazy_alg_subs()
         if isempty(algebraic_subs)
-            verbose && println("Lazily initilized algebraic substitutions for substituion of derivatives!")
+            verbose && println("Lazily initialized algebraic substitutions for substitution of derivatives!")
             merge!(algebraic_subs, _algebraic_substitution_rules(eqs)[1])
         end
         return algebraic_subs
@@ -327,11 +327,11 @@ end
     rename_vars(blk::IOBlock, subs::Dict{Symbolic,Symbolic}; warn=true)
 
 Returns new IOBlock which is similar to blk but with new variable names.
-Variable renamings should be provided as keyword arguments, i.e.
+Variable renaming should be provided as keyword arguments, i.e.
 
     rename_vars(blk; x=:newx, k=:knew)
 
-to rename `x(t)=>newx(t)` and `k=>knew`. Subsitutions can be also provided as
+to rename `x(t)=>newx(t)` and `k=>knew`. Substitutions can be also provided as
 dict of `Symbolic` types (`Sym`s and `Term`s).
 """
 function rename_vars(blk::IOBlock; warn=true, kwargs...)
@@ -359,7 +359,7 @@ end
 
 Substitutes certain parameters by actual Float values. Returns an IOBlock without those parameters.
 
-Keys of dict can be either `Symbols` or the `Sybolic` subtypes. I.e. `blk.u => 1.0` is as valid as `:u => 1.0`.
+Keys of dict can be either `Symbols` or the `Symbolic` subtypes. I.e. `blk.u => 1.0` is as valid as `:u => 1.0`.
 """
 function set_p(blk::IOBlock, p::Dict; warn=true)
     subs = Dict{Symbolic, Float64}()

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,7 +39,7 @@ end
 """
     _chkmsg(cond, msg)
 
-Create an expression which evaluates as a error string which contrains the original msg and
+Create an expression which evaluates as a error string which contains the original msg and
 some debug information based on the condition.
 """
 function _chkmsg(cond, msg)
@@ -178,7 +178,7 @@ lhs_var(eq::Equation) = eq_type(eq)[2]
 
 
 """
-    recusive_substitute(term, rules::Dict)
+    recursive_substitute(term, rules::Dict)
 
 Apply substitutions until there is no more change in `term`.
 """

--- a/test/BlockSystems_test.jl
+++ b/test/BlockSystems_test.jl
@@ -143,13 +143,13 @@ using Graphs
         @test_throws ArgumentError IOSystem([iob1.o => iob2.i], [iob1, iob2])
 
         iob2 = IOBlock([o ~ i],[i],[o])
-        # mulitiple conneections to same input
+        # multiple connections to same input
         @test_throws ArgumentError IOSystem([iob1.o => iob1.i, iob2.o => iob1.i], [iob1, iob2])
         # make sure that alle of form input => output
         @test_throws ArgumentError IOSystem([iob1.o => iob1.o], [iob1, iob2])
         @test_throws ArgumentError IOSystem([iob1.i => iob1.i], [iob1, iob2])
 
-        # assert that input maps refere to open inputs
+        # assert that input maps refer to open inputs
         @test_throws ArgumentError IOSystem([iob1.o => iob2.i], [iob1, iob2],
                                             namespace_map = [iob2.i => i])
         # assert that rhs of input map is unique

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -349,7 +349,7 @@ end
        sys = connect_system(sys)
        
        @test isequal(sys.removed_eqs, Equation[]) # no equations removed 
-       @test isequal(rhs_differentials(sys), Set{SymbolicUtils.Symbolic}()) # als rhs differentials have been resolved
+       @test isequal(rhs_differentials(sys), Set{SymbolicUtils.Symbolic}()) # all rhs differentials have been resolved
        @test isequal(equations(sys), [D(y) ~ x, x ~ x + y])
    end
    

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -332,6 +332,7 @@ end
                                   y ~ 2 + z,
                                   D(z) ~ 5*x + b]
     end
+
     @testset "Don't remove implicit differential equations" begin
        using BlockSystems:rhs_differentials
    

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -293,7 +293,7 @@ end
 
         @test equations(sysAC.system) == [D(o) ~ 2 + b, D(y) ~ 1 + b]
 
-        # fouth block with more complex stuff
+        # fourth block with more complex stuff
         @variables x(t) y(t)
         B = IOBlock([D(x) ~ a, y ~ x + 3], [], [y])
 
@@ -332,7 +332,27 @@ end
                                   y ~ 2 + z,
                                   D(z) ~ 5*x + b]
     end
-
+    @testset "Don't remove implicit differential equations" begin
+       using BlockSystems:rhs_differentials
+   
+       @parameters t y(t)
+       D = Differential(t)
+       @variables x(t)
+       
+       blk1 = IOBlock([x ~ y + D(y)], [y], [x]) # implicit differential equation
+       
+       @parameters x(t)
+       @variables y(t)
+       blk2 = IOBlock([D(y) ~ x], [x], [y])
+       
+       sys = IOSystem([blk1.x => blk2.x, blk2.y => blk1.y], [blk1, blk2], outputs = [blk1.x, blk2.y])
+       sys = connect_system(sys)
+       
+       @test isequal(sys.removed_eqs, Equation[]) # no equations removed 
+       @test isequal(rhs_differentials(sys), Set{SymbolicUtils.Symbolic}()) # als rhs differentials have been resolved
+       @test isequal(equations(sys), [D(y) ~ x, x ~ x + y])
+   end
+   
     @testset "set p" begin
         @parameters t a(t) b
         @variables x(t) y(t) z(t)

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -10,9 +10,9 @@ using ModelingToolkit.SymbolicUtils: operation
 @testset "utils.jl" begin
     @testset "check macro" begin
         @variables a b c d
-        @check Set([a, b, c]) ⊆ Set([a,b,c,d]) "Shoud be subset $a"
+        @check Set([a, b, c]) ⊆ Set([a,b,c,d]) "Should be subset $a"
         try
-            @check Set([a, b, c]) ⊆ Set([a,b,d]) "Shoud be subset"
+            @check Set([a, b, c]) ⊆ Set([a,b,d]) "Should be subset"
         catch e
             @test e isa ArgumentError
         end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -87,7 +87,7 @@ using ModelingToolkit.SymbolicUtils: operation
         using BlockSystems
         using BlockSystems: eq_type
         @parameters t
-        @variables x(t) y
+        @variables x(t) y z(t)
         D = Differential(t)
 
         @test eq_type(D(x) ~ 0) == (:explicit_diffeq, x.val)

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -90,14 +90,16 @@ using ModelingToolkit.SymbolicUtils: operation
         @variables x(t) y
         D = Differential(t)
 
-        @test eq_type(D(x) ~ 0) == (:diffeq, x.val)
-        @test eq_type(D(y) ~ 0) == (:diffeq, y.val)
+        @test eq_type(D(x) ~ 0) == (:explicit_diffeq, x.val)
+        @test eq_type(D(y) ~ 0) == (:explicit_diffeq, y.val)
         @test eq_type(x ~ 0) == (:explicit_algebraic, x.val)
         @test eq_type(y ~ 0) == (:explicit_algebraic, y.val)
         @test eq_type(x ~ x^2) == (:implicit_algebraic, x.val)
         @test eq_type(y ~ y^2) == (:implicit_algebraic, y.val)
         @test eq_type(y ~ x^2) == (:explicit_algebraic, y.val)
         @test eq_type(x ~ y^2) == (:explicit_algebraic, x.val)
+        @test eq_type(x ~ D(z)) == (:implicit_diffeq, x.val)
+        @test eq_type(y ~ D(z)) == (:implicit_diffeq, y.val)
         @test eq_type(0 ~ x + y) == (:implicit_algebraic, nothing)
     end
 


### PR DESCRIPTION
Equations of the kind: x ~ D(y) were seen as `:explicit_algebraic` and were removed during `substitute_algebraic_states`.  This can lead to problems as RHS differentials, like D(y), can potentially not be resolved in other equations, even if there is an equation for them. Thus we introduce the new type `:implicite_diffeq` to prevent these equations from being reduced. 