### PR TITLE
add :autocon option to create system connections

### DIFF
--- a/src/BlockSystems.jl
+++ b/src/BlockSystems.jl
@@ -233,10 +233,16 @@ Arguments:
    (and might be optimized away in `connect_system`).
  - `name`: namespace
  - `autopromote=true`: enable/disable automatic promotion of variable names to system namespace
+ - `globalp=Symbol[]`: List of symbols, which represent system-wide parameters
+   (iparams or inputs). All occurences in subsystems will be promoted to the
+   system namespace (i.e. if `globalp=[:K]`, each component block which has
+   some parameter `:K` will be represented by the same parameter rather than)
+   `blk1.K` and `blk2.K`.
 """
 function IOSystem(cons,
                   io_systems::Vector{<:AbstractIOSystem};
                   namespace_map = nothing,
+                  globalp=Symbol[],
                   outputs = :all,
                   name = gensym(:IOSystem),
                   autopromote = true)
@@ -291,21 +297,35 @@ function IOSystem(cons,
         nspcd_outputs  = outputs |> collect
     end
 
-    # auto promotion of the rest
+    # globalp promotions
     all_symbols = vcat(open_inputs, nspcd_iparams, nspcd_istates, nspcd_outputs, nspcd_rem_states)
+    if !isempty(globalp)
+        globalp = getname.(globalp) # just in case there are Syms/Terms
+        left_symbols = setdiff(all_symbols, keys(namespace_map))
+        for sym in left_symbols
+            # if the promoted symbol matches name of a globalp introduce promotion
+            if remove_namespace(getname(sym)) ∈ globalp
+                namespace_map[sym] = remove_namespace(sym)
+            end
+        end
+    end
+
+    # auto promotion of the rest
     left_symbols = setdiff(all_symbols, keys(namespace_map))
-
     auto_promotions = create_namespace_promotions(collect(left_symbols), values(namespace_map), autopromote)
-
     namespace_map = merge(namespace_map, auto_promotions)
 
     # assert that there are no namespace clashes. this should be allways true!
     @assert uniquenames(keys(namespace_map)) "ERROR: complete namespace map lhs not unique: $namespace_map"
-    @assert uniquenames(values(namespace_map)) "ERROR: complete namespace map rhs not unique: $namespace_map"
+
+    if !uniquenames(values(namespace_map))
+        dups = duplicates(namespace_map)
+        @check dups ⊆ globalp "There are duplicate entries in the RHS of the namespace map, which are not in `globalp`!"
+    end
 
     nmspc_promote = ModelingToolkit.substituter(namespace_map)
-    inputs  = nmspc_promote.(open_inputs)
-    iparams = nmspc_promote.(nspcd_iparams)
+    inputs  = unique!(nmspc_promote.(open_inputs))   # global p might reduce the inputs
+    iparams = unique!(nmspc_promote.(nspcd_iparams)) # and iparams
     istates = nmspc_promote.(nspcd_istates)
     outputs = nmspc_promote.(nspcd_outputs)
     rem_states = nmspc_promote.(nspcd_rem_states)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -5,13 +5,13 @@
 Helper function for `Base.show` for IOBlock and IOSystem
 """
 function print_variables(io::IO, V)
-    printmax = get(io, :compact, false) ? 3 : 7
+    printmax = get(io, :compact, false) ? 4 : 7
     l = length(V)
     if l == 0
         print(io, "(empty)")
         return
     elseif l > printmax
-        print(io, V[1], ", …$(l-2)…,", V[end])
+        print(io, V[1],", ", V[2], ", …$(l-3)…,", V[end])
     else
         for (i, v) in enumerate(V)
             print(io, v)
@@ -23,7 +23,7 @@ end
 function Base.show(io::IO, iob::IOBlock)
     compact = get(io, :compact, false)
     ioc = IOContext(io, :compact => true)
-    if ~compact
+    if !compact
         eqs = equations(iob.system)
         Base.printstyled(io, "IOBlock :$(iob.name) with $(length(eqs)) eqs", bold=true)
         print(io, "\n  ├ inputs:  "); print_variables(io, iob.inputs)
@@ -45,7 +45,7 @@ end
 function Base.show(io::IO, ios::IOSystem)
     compact = get(io, :compact, false)
     ioc = IOContext(io, :compact => true)
-    if ~compact
+    if !compact
         Base.printstyled(io, "IOSystem :$(ios.name) with $(length(ios.systems)) subsystems", bold=true)
         for (i, sub) in enumerate(ios.systems)
             s = i == length(ios.systems) ? "└ " : "├ "
@@ -65,7 +65,7 @@ function Base.show(io::IO, ios::IOSystem)
             unpromoted = filter(v -> v ∈ all_unpromoted, vec)
             promoted = filter(v -> v ∉ all_unpromoted, vec)
 
-            if ~isempty(unpromoted)
+            if !isempty(unpromoted)
                 s = isempty(promoted) ? "└ " : "├ "
                 print(ioc, "\n  ", s)
                 print_variables(io, unpromoted)
@@ -74,8 +74,10 @@ function Base.show(io::IO, ios::IOSystem)
 
             for (i, v) in enumerate(promoted)
                 s = i == length(promoted) ? "└ " : "├ "
-                key = findfirst(val->isequal(val, v), ios.namespace_map)
-                print(ioc, "\n  ", s, key, " ⇒ ", ios.namespace_map[key])
+                keys = findall(val->isequal(val, v), ios.namespace_map)
+                print(ioc, "\n  ", s)
+                print_variables(ioc, keys)
+                print(ioc, " ⇒ ", v)
             end
         end
         Base.printstyled(io, "\ninputs:", bold=true)

--- a/test/BlockSystems_test.jl
+++ b/test/BlockSystems_test.jl
@@ -452,4 +452,33 @@ using Graphs
         IOSystem(:autocon, [blk1, blk2, blk3])
         IOSystem(:autocon, [blk1, blk3, blk4])
     end
+
+    @testset "globalp" begin
+        @variables t a(t) b(t) c(t)
+        @parameters i(t) K
+        @named blk1 = IOBlock([a ~ K*i, b ~ 2, c ~ 3],
+                              [i], [a,b,c])
+        @named blk2 = IOBlock([a ~ K*i],
+                              [i], [a])
+
+        sys = IOSystem(:autocon, [blk1, blk2]) |> connect_system
+        @test Set(sys.iparams) == Set([blk1.K, blk2.K])
+        @test Set(sys.inputs) == Set([blk1.i, blk2.i])
+
+        sys = IOSystem(:autocon, [blk1, blk2]; globalp=[:foo]) |> connect_system
+        @test Set(sys.iparams) == Set([blk1.K, blk2.K])
+        @test Set(sys.inputs) == Set([blk1.i, blk2.i])
+
+        sys = IOSystem(:autocon, [blk1, blk2]; globalp=[:K]) |> connect_system
+        @test Set(sys.iparams) == Set([K])
+        @test Set(sys.inputs) == Set([blk1.i, blk2.i])
+
+        sys = IOSystem(:autocon, [blk1, blk2]; globalp=[:i]) |> connect_system
+        @test Set(sys.iparams) == Set([blk1.K, blk2.K])
+        @test Set(sys.inputs) == Set([i])
+
+        sys = IOSystem(:autocon, [blk1, blk2]; globalp=[:i, :K]) |> connect_system
+        @test Set(sys.iparams) == Set([K])
+        @test Set(sys.inputs) == Set([i])
+    end
 end


### PR DESCRIPTION
This PR adds two new features for `IOSystems` creations.

First, with the keyword argument `globalp` you can define at system definition time, that some of the internal parameters or some of the inputs should be used systemwide. For example, if you define `globalp = [:ω0]`, each sublock which has a parameter `ω0` will be mapped to a single unique parameter `ω0` of the composite system. Similar, lets say you have several blocks for referenc frame conversion which have the input `δ(t)`, by defining `globalp = [:δ]` all those inputs will be merged on the composite system rathe than having `[rfc1.δ, rfc2.δ, ...]`.

Seconly, there is a feature now for autoconnections. BlockSystems will connect outputs with inputs by name.

There is one open question: what should happen if multiple inputs match a single output? Should we connect all of them (Option B) or none of them (Option A)? EDIT: I tend towards option B, this might be handy for example in the referenc frame conversion block example above. Option B is implemented in this PR currently.

```julia
        @variables t a(t) b(t) c(t)
        @named blk1 = IOBlock([a ~ 1, b ~ 2, c ~ 3],
                              [], [a,b,c])
        @variables o1(t)
        @parameters a(t) b(t) c(t)
        @named blk2 = IOBlock([o1 ~ a + b + c],
                              [a, b, c],
                              [o1])
        @variables o2(t)
        @named blk3 = IOBlock([o2 ~ a + b],
                              [a, b],
                              [o2])

        IOSystem(:autocon, [blk1, blk2, blk3]) # creates 3 connections
        IOSystem(:autocon, [blk1, blk2]) # creates either 1 or 5 connections

```
![grafik](https://user-images.githubusercontent.com/35867212/176917949-06897258-5e93-4779-b492-c6ce5bc2d1bc.png)
