### PR TITLE
qualilty of life

### DIFF
--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -318,6 +318,7 @@ function rename_vars(blk::IOBlock; warn=true, kwargs...)
 end
 
 function rename_vars(blk::IOBlock, subs::Dict{Symbolic,Symbolic}; warn=true)
+    isempty(subs) && return blk
     eqs     = map(eq->eqsubstitute(eq, subs), get_eqs(blk.system))
     rem_eqs = map(eq->eqsubstitute(eq, subs), blk.removed_eqs)
     inputs  = map(x->substitute(x, subs), blk.inputs)

--- a/test/BlockSystems_test.jl
+++ b/test/BlockSystems_test.jl
@@ -481,4 +481,20 @@ using Graphs
         @test Set(sys.iparams) == Set([K])
         @test Set(sys.inputs) == Set([i])
     end
+
+    @testset "system output specification" begin
+        @variables t o(t)
+        @parameters i(t)
+        @named blkA = IOBlock([o ~ 1 + i], [i], [o])
+        @named blkB = IOBlock([o ~ 2 + i], [i], [o])
+
+        sys = IOSystem([blkA.o => blkB.i], [blkA, blkB]) |> connect_system
+        @test Set(sys.outputs) == Set([blkA.o, blkB.o])
+
+        sys = IOSystem([blkA.o => blkB.i], [blkA, blkB], outputs=[blkB.o]) |> connect_system
+        @test Set(sys.outputs) == Set([blkB.o])
+
+        sys = IOSystem([blkA.o => blkB.i], [blkA, blkB], outputs=:remaining) |> connect_system
+        @test Set(sys.outputs) == Set([blkB.o])
+    end
 end

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -442,6 +442,34 @@ end
         @test_throws ArgumentError blk2 = set_p(blk, x=>2.0)
     end
 
+    @testset "transform inputs to iparams and vice versa" begin
+        using BlockSystems: make_input, make_iparam
+        @variables t out(t)
+        @parameters in(t) p
+
+        blkA = IOBlock([out ~ in + p], [in], [out])
+
+        @test_throws ArgumentError make_input(blkA, :in)
+        blkB1 = make_input(blkA, :p)
+        blkB2 = make_input(blkA, p)
+        blkB3 = make_input(blkA, blkA.p)
+        @test isempty(blkB1.iparams)
+        @test isempty(blkB2.iparams)
+        @test isempty(blkB3.iparams)
+        @test Set(blkB1.inputs) == Set(blkB2.inputs) == Set(blkB3.inputs)
+        @test length(blkB1.inputs) == 2
+
+        @test_throws ArgumentError make_iparam(blkA, :p)
+        blkC1 = make_iparam(blkA, :in)
+        blkC2 = make_iparam(blkA, in)
+        blkC3 = make_iparam(blkA, blkA.in)
+        @test isempty(blkC1.inputs)
+        @test isempty(blkC2.inputs)
+        @test isempty(blkC3.inputs)
+        @test Set(blkC1.iparams) == Set(blkC2.iparams) == Set(blkC3.iparams)
+        @test length(blkC1.iparams) == 2
+    end
+
     @testset "simplify eqs" begin
         @parameters t a
         @variables x(t)

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -411,6 +411,37 @@ end
         @test_throws ArgumentError blk2 = set_p(blk, x=>2.0)
     end
 
+    @testset "set p for inputs" begin
+        @parameters t a(t) b(t)
+        @variables x(t) y(t) z(t)
+        D = Differential(t)
+
+        blk = IOBlock([D(x) ~ 1 + D(y) + a + b], [a, b], [])
+
+        blk2 = set_p(blk, :a=>0)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + b]
+        blk2 = set_p(blk, blk.a=>0)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + b]
+        blk2 = set_p(blk, a=>0)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + b]
+
+        blk2 = set_p(blk, :b=>1)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + a + 1]
+        blk2 = set_p(blk, blk.b=>1)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + a + 1]
+        blk2 = set_p(blk, b=>1)
+        @test equations(blk2) == [D(x) ~ 1 + D(y) + a + 1]
+
+        blk2 = set_p(blk, Dict(blk.a=>2, b=>4))
+        @test equations(blk2) == [D(x) ~ 7 + D(y)]
+
+        blk2 = set_p(blk, blk.a=>2, b=>4; warn=false)
+        @test equations(blk2) == [D(x) ~ 7 + D(y)]
+
+        @test_throws ArgumentError blk2 = set_p(blk, :a=>:bla)
+        @test_throws ArgumentError blk2 = set_p(blk, x=>2.0)
+    end
+
     @testset "simplify eqs" begin
         @parameters t a
         @variables x(t)


### PR DESCRIPTION
## `outputs=:remaining`
Upon creating an `IOSystem`, you can now remove "used" outputs automaticially, i.e. they won't become outputs of the composite system.

## `set_p` for inputs
`set_p(blk, :a=>3, :b=>4)` can be used to set inputs to fixed float values
eventually, i'd like to merge this function with `rename_vars`. Renaming and explicit closing/setting of inputs/iparams are very common task in building complex structures out of smaller building blocks

## `make_input` and `make_iparam`
`make_input(blk, blk.p)` (or `make_input(blk, :p`) can be used to transform  iparams to inputs (`make_iparam` works the other way around)

## `@connect` macro
shorthand to create composite systems (and connect them to blocks)
```julia
@connect a.out=>b.in
```
also works with multiple variables
```julia
@connect a.(out1, out2)=>b.(in1, in2)
```
multiple connections may be defined at once
```julia
@connect a.out=>c.in1 b.out=>c.in2
```
add kw args to `IOSystem` constructor if necessary, i.e.
```julia
@connect a.out=>c.in1 b.out=>c.in2 name=:foo outputs=:remaining
```